### PR TITLE
Update ensemble.py

### DIFF
--- a/deepstack/ensemble.py
+++ b/deepstack/ensemble.py
@@ -10,7 +10,7 @@ import os
 import joblib
 import glob
 from deepstack.base import Member
-from keras.utils import to_categorical
+from tensorflow.keras.utils import to_categorical
 
 
 class Ensemble(object):


### PR DESCRIPTION
while running this line "from deepstack.ensemble import DirichletEnsemble" error is cannot import name 'to_categorical' from 'keras.utils' (/usr/local/lib/python3.7/dist-packages/keras/utils/__init__.py) if we use "from tensorflow.keras.utils import to_categorical" in place of "from keras.utils import to_categorical" then this error will be resolved.