### PR TITLE
Fixing ImportError

### DIFF
--- a/deepstack/ensemble.py
+++ b/deepstack/ensemble.py
@@ -10,7 +10,7 @@ import os
 import joblib
 import glob
 from deepstack.base import Member
-from keras.utils import to_categorical
+from tensorflow.keras.utils import to_categorical
 
 
 class Ensemble(object):


### PR DESCRIPTION
/opt/conda/lib/python3.7/site-packages/deepstack/ensemble.py in <module>
     11 import glob
     12 from deepstack.base import Member
---> 13 from keras.utils import to_categorical
     14 
     15 

ImportError: cannot import name 'to_categorical' from 'keras.utils' (/opt/conda/lib/python3.7/site-packages/keras/utils/__init__.py)